### PR TITLE
Fix infinite recursion bug, make sure numbers always come before letters

### DIFF
--- a/src/comparer/text.ts
+++ b/src/comparer/text.ts
@@ -75,6 +75,10 @@ const compare = ({
 		isNumber: bIsNumber,
 	} = getCharAndShift(b, bIndex);
 
+	// make sure numbers come before letters
+	if (aIsNumber != bIsNumber) {
+		return compareNumber(Number(!aIsNumber), Number(!bIsNumber))
+	}
 	const aCharIndex = aIsNumber ? aNumber : getIndex(aCurrentChar, removeAccent);
 	const bCharIndex = bIsNumber ? bNumber : getIndex(bCurrentChar, removeAccent);
 

--- a/test/hunsorter.test.ts
+++ b/test/hunsorter.test.ts
@@ -3,12 +3,14 @@ import sorting from '../src/main';
 
 test('Rendezés, ha számokat tartalmaz', () => {
 	const array = [
+		'0',
 		'1. c.',
 		' 8.a osztály',
 		'9. b. IV. csoport',
 		'9/c 2. csoport',
 		'11',
 		'12. szak',
+		'a',
 	];
 
 	const shuffled = shuffle(array);


### PR DESCRIPTION
If the only difference in two words was a number and a non-special character whose index is the same as the number itself the program would enter an infinite recursion. I fixed the error by enforcing that the number always comes before the letter. I also added a test to validate the fix.

To reproduce the issue:
```javascript
import sorting from hunsorter;

const fruits = ['a', '0'];

fruits.sort(sorting);
```
